### PR TITLE
Add @include block-skin mixin. See #19 and #14.

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -68,7 +68,8 @@ $ms14			 	: 100;
 // UI
 
 $radius			: 5px;
-$border			: 1px;
+$border-width	: 1px;
+$border-style	: solid;
 $depth			: 0%; // Range: 0-100%
 $contrast		: 91%; // Range: 0-100%
 $shadow			: 21%; // Range: 0-100%

--- a/scss/shared/_mixins.scss
+++ b/scss/shared/_mixins.scss
@@ -21,9 +21,9 @@
 @mixin text-color($c1) {
 	// Calculations based on https://vimeo.com/60224584
 	@if (.2126*red($c1) + .7152*green($c1) + .0722*blue($c1))/255 <= .5 {
-		color: #FFF;
+		color: mix(#FFF,$c1,95%);
 	} @else {
-		color: #000;
+		color: mix(#000,$c1,70%);
 	}
 }
 
@@ -44,13 +44,27 @@
 
 // UI mixins.
 
-@mixin block($color, $top: 1.5, $right: 1, $bottom: 1.5, $left: 1){
-	background-color: $color;
-	padding: #{$alpha-line-height * 1em * $top} #{$grid-margin * $right * 1px} #{$alpha-line-height * 1em * $bottom} #{$grid-margin * $left * 1px};
+// Make a block with various properties
+// @include block-skin;
+@mixin block-skin($bgcolor: $gamma-ui-color, $fgcolor: $alpha-text-color, $block-radius: $radius, $block-border-width: $border-width, $block-border-style: $border-style) {
+
+	background-color: $bgcolor;
+	border-color: darken($bgcolor,100%-$contrast);
+	border-style: $border-style;
+
+	@if (su($block-radius) > 0) {
+		border-radius: $block-radius;
+	}
+
+	@if (su($block-border-width) > 0) {
+		border-width: $block-border-width;
+	}
+
+	@include text-color($bgcolor);
+
 }
 
 // Cross browser background opacity.
-
 @mixin background-opacity($color, $alpha) {
 	$rgba: rgba($color, $alpha);
 	$ie-hex-str: ie-hex-str($rgba);

--- a/scss/shared/_ui.scss
+++ b/scss/shared/_ui.scss
@@ -58,7 +58,7 @@
 
 @mixin btn-color($c1: $alpha-ui-color, $c2: lighten($c1, $depth)) {
 
-	border: $border solid $c1;
+	border: $border-width $border-style $c1;
 
 	background-color: $c1;
 	@if $depth > 0 {
@@ -73,7 +73,7 @@
 
 	&:hover,
 	&:focus {
-		border: $border solid lighten($c1, 100-$contrast);
+		border: $border-width $border-style lighten($c1, 100-$contrast);
 		background-color: lighten($c1, 100-$contrast);
 		@if $depth > 0 {
 			background-image: linear-gradient(lighten($c1, 100-$contrast), lighten($c2, 100-$contrast));
@@ -111,7 +111,6 @@
 		$line-height: ((ceil($alpha-font-size/$alpha-baseline-grid)*$alpha-baseline-grid)+($alpha-baseline-grid*$l))/$alpha-font-size;
 		$padding-top: $alpha-baseline-grid/$alpha-font-size*$pt*1em;
 		$padding-bottom: $alpha-baseline-grid/$alpha-font-size*$pb*1em;
-		$border-width: em(su($border));
 		height: $line-height + $padding-top + $padding-bottom;
 	}
 
@@ -154,11 +153,15 @@
 // Alerts
 
 %alert {
-	border-width: $border;
-	border-style: solid;
-	margin-bottom: #{$alpha-line-height}em;
 	position: relative;
 	padding: em($alpha-baseline-grid*2) em($alpha-baseline-grid*3);
+	margin-bottom: em($alpha-baseline-grid*2);
+	cursor: pointer;
+	@include block-skin;
+
+	a {
+		text-decoration: underline;
+	}
 
 	a:hover,
 	a:active,
@@ -166,7 +169,7 @@
 		text-decoration: none;
 	}
 
-	.close {
+	a.close {
 		position: absolute;
 		top: #{$alpha-line-height/2}em;
 		right: #{$alpha-line-height/2}em;
@@ -182,25 +185,17 @@
 
 @mixin alert {
 	@extend %alert;
-	border-radius: $radius;
-	cursor: pointer;
-	border-color: darken($gamma-ui-color,20%);
-	background-color: $gamma-ui-color;
-	@include text-color($gamma-ui-color);
 
 	strong {@include text-color($gamma-ui-color);}
 
 	a {
 		@include text-color($gamma-ui-color);
-		text-decoration: underline;
 	}
 }
 
 @mixin alert-error {
 	@extend %alert;
-	border-color: darken($error-color,10);
-	background-color: $error-color;
-	@include text-color($error-color);
+	@include block-skin($error-color);
 
 	strong {@include text-color($error-color);}
 
@@ -211,9 +206,7 @@
 
 @mixin alert-success {
 	@extend %alert;
-	border-color: darken($success-color,10);
-	background-color: $success-color;
-	@include text-color($success-color);
+	@include block-skin($success-color);
 
 	strong {@include text-color($success-color);}
 
@@ -224,9 +217,7 @@
 
 @mixin alert-notice {
 	@extend %alert;
-	border-color: darken($notice-color,20);
-	background-color: $notice-color;
-	@include text-color($notice-color);
+	@include block-skin($notice-color);
 
 	strong {@include text-color($notice-color);}
 

--- a/scss/theme/_forms.scss
+++ b/scss/theme/_forms.scss
@@ -42,7 +42,7 @@ textarea {
 			font-smoothing: antialiased;
 	background-color: $delta-ui-color;
 	border-radius: $radius;
-	border: $border solid $gamma-ui-color;
+	border: $border-width $border-style $gamma-ui-color;
 	color: lighten($alpha-text-color, 30);
 	font-family: $alpha-font-family;
 	margin: 0;


### PR DESCRIPTION
Proposal to add a `block-skin` mixin as noted in #19 and #14 

Summary:
- Split global variable `$border` into `$border-width` and `$border-style`.
- Add a `block-skin` mixin to add a skin onto a block element. Default values are based on chopstick settings
- Make the alerts use the block-skin mixin.

Usage (variables between square brackets are optional):

```
@include block-skin([$bgcolor] [$fgcolor] [$block-radius] [$block-border-width] [$block-border-style])
```

You can simply do the following:

```
span.element {
    display: block
    @include block-skin;
}
```

Which will result in a block based on the default chopstick settings. You can override those settings:

```
span.element--alt {
    display: inline-block;
    @include block-skin(#FFF, #CCC, 0, 1px, dotted);
}
```

The `display` property was not included in the block-skin mixin because it would lead to code duplication. Most elements already have a display style of block by default, so it would be redundant. And chopstick is light-weight!
