### PR TITLE
Fix css injection

### DIFF
--- a/_gulp/tasks/scss.js
+++ b/_gulp/tasks/scss.js
@@ -30,6 +30,6 @@ gulp.task('scss', function () {
         .pipe(filesize())
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest(config.jekyllCssDes))
-        .pipe(browserSync.reload({stream:true}))
+        .pipe(browserSync.stream({match: '**/*.css'}))
         .pipe(gulp.dest(config.cssDest))
 });


### PR DESCRIPTION
#### The issue
I noticed that, on css changes, **the site gets reloaded instead of doing a css injection.**
Removing sourcemap generation from the pipe fixed the css injection issue, so the problem is sourcemap related.

#### Solution
The problem is that the `.map` files are generated and end up being sent down stream and when `browsersync.reload` receives them, it will attempt a full page reload (as it will not find any `.map` files in the DOM).

To fix this problem, `use browserSync.stream({match: '**/*.css'})`