### PR TITLE
Gulp: trigger jekyll build from all html files

### DIFF
--- a/_gulp/config.js
+++ b/_gulp/config.js
@@ -67,11 +67,9 @@ module.exports = {
             path + 'img/*.png',
             path + 'img/*.jpg',
             path + 'img/*.svg',
-            path + '_includes/**/*.html',
-            path + '_layouts/*.html',
             path + '_posts/*.md',
             path + '_data/*.yml',
-            path + '*.html'
+            path + '**/*.html'
         ]
     },
 

--- a/_gulp/config.js
+++ b/_gulp/config.js
@@ -69,7 +69,8 @@ module.exports = {
             path + 'img/*.svg',
             path + '_posts/*.md',
             path + '_data/*.yml',
-            path + '**/*.html'
+            path + '**/*.html',
+            '!' + path + '_site/**/*.*'
         ]
     },
 


### PR DESCRIPTION
When using sub directories on more complex projects, Gulp did not trigger a jekyll rebuild. Now it does. Doesn’s seem to break anything here, but might be good for someone to check.