### PR TITLE
Run default tasks at least once before watch

### DIFF
--- a/_gulp/config.js
+++ b/_gulp/config.js
@@ -64,9 +64,9 @@ module.exports = {
 
     watch: {
         jekyllSource: [    // Files that trigger a Jekyll rebuild
-            path + 'img/*.png',
-            path + 'img/*.jpg',
-            path + 'img/*.svg',
+            path + 'img/**/*.png',
+            path + 'img/**/*.jpg',
+            path + 'img/**/*.svg',
             path + '_posts/*.md',
             path + '_data/*.yml',
             path + '**/*.html',

--- a/_gulp/tasks/watch.js
+++ b/_gulp/tasks/watch.js
@@ -9,7 +9,7 @@ var gulp = require('gulp');
 var config = require('../config');
 
 // task
-gulp.task('watch', ['browsersync'], function () {
+gulp.task('watch', ['default','browsersync'], function () {
     gulp.watch(config.scss.src, ['scss']);
     gulp.watch(config.js.src, ['js--reload']);
     gulp.watch(config.watch.jekyllSource, ['jekyll--rebuild']);


### PR DESCRIPTION
This improves the first-run `gulp watch` experience by running the `default` gulp task first, then continuing to `watch`