### PR TITLE
Remove html5shiv

### DIFF
--- a/_includes/generic.head.html
+++ b/_includes/generic.head.html
@@ -19,8 +19,6 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="css/screen.css">
 
-    <!-- Enable HTML5 in IE<9 -->
-    <!--[if lt IE 9  & (!IEMobile)]><script src="/vendor/html5shiv/dist/html5shiv.min.js"></script><![endif]-->
     <link rel="icon" href="/favicon.png">
     <!--
         Place all other favicons in website root (e.g. http://web.dev/favicon.ico).

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
     "chopstick-elements": ">=0.7.8",
     "chopstick-objects": ">=0.7.6",
     "chopstick-utilities": ">=0.7.5",
-    "html5shiv": "~3.7.0",
     "jquery": "~1.11.1",
     "modernizr": "~2.8.3",
     "respond": "~1.4.1"


### PR DESCRIPTION
Html5shiv was a way to enable html5 elements in legacy Internet Explorer versions (<IE9). 
Microsoft recently [killed IE 8,9,10](http://thenextweb.com/microsoft/2016/01/05/web-developers-rejoice-internet-explorer-8-9-and-10-die-on-tuesday/) so seems logical that we can remove html5shiv now from chopstick? 

Resolves #116 